### PR TITLE
Update dependency versions to fix mocha-phantomjs tests issues for using PhantomJS 2.1.1

### DIFF
--- a/ambari-web/app/assets/test/test.html
+++ b/ambari-web/app/assets/test/test.html
@@ -41,6 +41,7 @@
 <script>
     $.mocho = true;
     $.hostName = 'localhost:3333';
+    window.initMochaPhantomJS && window.initMochaPhantomJS();
     mocha.ui('bdd');
     mocha.reporter('html');
     expect = chai.expect;

--- a/ambari-web/package.json
+++ b/ambari-web/package.json
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "phantomjs": "^1.9.2",
-    "mocha":"1.9.0",
-    "mocha-phantomjs": "~3.1.6",
+    "mocha":"1.21.5",
+    "mocha-phantomjs": "~4.1.0",
     "chai":"~1.9.0",
     "sinon":"=1.7.3",
     "sinon-chai":"~2.5.0",


### PR DESCRIPTION
Mocha-phantomjs tests hang while using PhantomJS version 2.1.1 on ppc64le. Updates are made in package.json and test.html file to fix these tests issues. 

